### PR TITLE
Caching `jenv.from_string` with cache size and toggle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Lightweight wrapper around sqlalchemy + jinja2.
 
 ```
-pip install jsql==0.9
+pip install jsql==0.91
 ```
 
 ## Usage
@@ -40,4 +40,3 @@ with engine.begin() as conn:
 1) Variables injected as `:var_tuple_list` will expect a list of tuples and will be escaped by SQL driver for use as eg `(id1, id2) IN :id_tuple_list` (see `test_list_param`)
 1) Variables injected using `{{var}}` will be inserted directly into the query but will be checked against jsql.NOT_DANGEROUS_RE (default `[A-Za-z0-9_]+`). This is intended for templating table names, limits, etc where SQL query placeholders are not allowed. (see `test_render`)
 1) Variables injected using `{{var | dangerously_inject_sql }}` will be inserted directly into the query without any checks (probably a bad idea) (see `test_render`)
-

--- a/jsql/__init__.py
+++ b/jsql/__init__.py
@@ -34,21 +34,55 @@ def sql_inner(engine, template, params):
 
 sql_inner_original = sql_inner
 
-MAX_CACHE_SIZE = int(os.getenv("JINJA_FROM_STRING_CACHE_SIZE", "4096"))
+DEFAULT_MAX_CACHE_SIZE = 4096
 
-@functools.lru_cache(maxsize=MAX_CACHE_SIZE)
-def compile_template_cached(template):
+
+def _make_cached_compiler(maxsize):
+    @functools.lru_cache(maxsize=maxsize)
+    def _compile(template):
+        return jenv.from_string(template)
+    return _compile
+
+compile_template_cached = _make_cached_compiler(DEFAULT_MAX_CACHE_SIZE)
+
+def compile_template_nocache(template):
     return jenv.from_string(template)
+
+compile_template = compile_template_cached
+
 
 def render(template, params):
     params['bindparam'] = params.get('bindparam', gen_bindparam(params))
+    return compile_template(template).render(**params)
 
-    if os.getenv("DISABLE_JINJA_FROM_STRING_CACHE", "0") in (
-            "1", "true", "True",
-    ):
-        return jenv.from_string(template).render(**params)
 
-    return compile_template_cached(template).render(**params)
+def enable_template_cache(maxsize=DEFAULT_MAX_CACHE_SIZE):
+    """Enable caching with the given size by swapping the function reference."""
+    global compile_template, compile_template_cached
+    compile_template_cached = _make_cached_compiler(maxsize)
+    compile_template = compile_template_cached
+
+
+def disable_template_cache():
+    """Disable caching by swapping to the non-cached implementation."""
+    global compile_template
+    compile_template = compile_template_nocache
+
+
+def clear_template_cache():
+    """Clear the current cached compiler if in cached mode."""
+    try:
+        compile_template_cached.cache_clear()
+    except Exception:
+        pass
+
+
+def template_cache_info():
+    """Return cache info if in cached mode; else None."""
+    try:
+        return compile_template_cached.cache_info()
+    except Exception:
+        return None
 
 logger = logging.getLogger('jsql')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jsql',
-    version='0.9',
+    version='0.91',
     author='Hisham Zarka',
     author_email='hzarka@gmail.com',
     packages = find_packages(),
@@ -19,4 +19,3 @@ setup(
     ],
     zip_safe=True,
 )
-


### PR DESCRIPTION
## Description

The compilation of the jinja templates takes a lot of time, and can be cached for each sql-query template. The cached templates can be useful as it reduces a lot of time for each query done using jsql.

It was first implemented as a monkey patch for tests which improved the tests runtime by 50%. [Analysis](https://docs.google.com/document/d/1MVCuwcuzeizf9eqjkkfPenGnSxsczSUOj7_HUFzLl8A/edit?tab=t.0#heading=h.o1kgnbizkqwk)
Has been used by other teams as well. It also helped in reducing the costs by ~60%. [Ref](https://chat.google.com/room/AAAAhTQk6Ow/xdtTYxI52lo/eHSPpYyP7K0?cls=10)

Now using this change, it has shown improvement in API latency and CPU usage time. [This dashboard](https://console.cloud.google.com/monitoring/dashboards/builder/a4dcc0d7-3028-469a-86d7-fa1dc4eb282b;startTime=2025-09-11T15:00:45.282Z;endTime=2025-09-18T15:42:45.282Z?inv=1&invt=Ab2MBQ&project=noonprd-fd&pageState=(%22eventTypes%22:(%22selected%22:%5B%22CLOUD_ALERTING_ALERT%22,%22GKE_WORKLOAD_DEPLOYMENT%22%5D))) shows the latencies and cpu usage compared to the previous week of the deploying this change. 

