### PR TITLE
Add SQLAlchemy 2.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ setup(
     author_email='hzarka@gmail.com',
     packages = find_packages(),
     package_dir = {'': '.'},
-    requires = ["six"],
-    install_requires = ["six"],
+    requires = ["six", "packaging"],
+    install_requires = ["six", "packaging"],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
## Summary
- Add support for SQLAlchemy 2.0's unified execute() API
- SQLAlchemy 2.0 no longer accepts **kwargs for Connection.execute(), requires dict instead
- Uses `packaging` library for robust version detection (PEP 440 compliant)
- Raises clear TypeError if Engine is passed directly (Engine.execute() was removed in 2.0)

## Changes
- Detect SQLAlchemy version at import time using `packaging.version`
- For SQLAlchemy >= 2.0: pass params as dict, error if Engine passed
- For SQLAlchemy < 2.0: preserve existing behavior (Session uses params=, Connection uses **kwargs)
- Added `packaging` as dependency